### PR TITLE
[Bug Fix] eslint prettier 에러 해결

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,4 +22,19 @@ module.exports = {
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
   },
+  'prettier/prettier': [
+    'error',
+    {
+      arrowSpacing: ['error', { before: true, after: true }],
+      singleQuote: true,
+      semi: false,
+      useTabs: false,
+      tabWidth: 2,
+      trailingComma: 'none',
+      printWidth: 80,
+      bracketSpacing: true,
+      arrowParens: 'always',
+      endOfLine: 'auto', // 이 부분이 lf로 되어있다면 auto로 변경
+    },
+  ],
 };


### PR DESCRIPTION
#6 개발 중 발생한 버그 FIX
맥과 윈도우 OS간 줄바꿈 차이로 발생하는 버그 발생
-> eslintrc.js 파일에 endOfLine 내용 추가해서 해결 완료 

참고 문서: https://stack94.tistory.com/entry/Prettier-eslint-delete-CR-prettierprettier-%EC%97%90%EB%9F%AC