### PR TITLE
[Fix] 탐색 메인 화면: 인기, 최신 시그니처 정렬 함수 로직 변경

### DIFF
--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -30,7 +30,7 @@ export class SearchService{
       const recentSignatures: SignatureEntity[] = await SignatureEntity.findRecentSignatures();
 
       // [2] 최근 시그니처들 리스트 좋아요 순으로 정렬
-      recentSignatures.sort((a,b) => a.liked - b.liked );
+      recentSignatures.sort((a,b) => b.liked - a.liked );
       console.log(recentSignatures);
 
       // [3] 그 중에서 20개만 리턴한다
@@ -66,7 +66,8 @@ export class SearchService{
       }
 
       // [3] 최신 순으로 정렬
-      totalNewSignatures.sort((a,b)=>a.created.getDate()-b.created.getDate());
+      totalNewSignatures.sort((a, b) => b.created.getTime() - a.created.getTime());
+
 
       // [4] 20개만 리턴
       return await this.getSignatureCoversForSearchMain(totalNewSignatures);


### PR DESCRIPTION

## 요약
[Fix] 탐색 메인 화면: 인기 시그니처 정렬 함수 로직 변경
<br><br>

## 작업 내용
-인기 급상승 시그니처 정렬 -> 좋아요 순서대로
-메이트의 최신 시그니처 정렬 -> 최신순으로 밀리초까지 비교하도록 수정했습니다.
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #70 
- Close #53 

<br><br>

