### PR TITLE
fix: preSignedURL로 이미지가 업로드되지 않는 문제를 수정하라

### DIFF
--- a/src/utils/S3.service.ts
+++ b/src/utils/S3.service.ts
@@ -41,7 +41,7 @@ export class S3UtilService {
   }
 
   public async getPresignedUrl(key: string) {
-    return this.s3.getSignedUrlPromise('getObject', {
+    return this.s3.getSignedUrlPromise('putObject', {
       Bucket: process.env.S3_BUCKET_NAME,
       Key: key,
       Expires: 60,


### PR DESCRIPTION
## 요약
Presigned URL로 이미지를 업로드할 때 에러가 발생한다.
<br><br>

## 작업 내용
- [x] Presigned URL로 이미지를 업로드 할 때 발생하는 오류를 수정
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #88
<br><br>
