### PR TITLE
[FEAT] 월별 일정 API

### DIFF
--- a/src/map/map.service.ts
+++ b/src/map/map.service.ts
@@ -25,10 +25,12 @@ export class MapService {
           journey.id,
           monthInfoDto,
         );
+        console.log(schedules);
         const locations = await this.getLocationList(schedules);
         const images = await this.getDiaryImageList(schedules);
         const mapInfo = schedules.map((schedule, index) => {
           return {
+            date: schedules[index].date,
             location: locations[index],
             diaryImage: images[index],
           };
@@ -188,10 +190,27 @@ export class MapService {
   }
 
   //사용자의 월별 일정 가지고 오기
-  async getMonthlySchedule(journeyId, monthInfoDto: MonthInfoDto) {
+  async getMonthlySchedule(
+    journeyId,
+    monthInfoDto: MonthInfoDto,
+  ): Promise<ScheduleEntity[]> {
     const schedules: ScheduleEntity[] =
       await ScheduleEntity.findMonthlySchedule(journeyId, monthInfoDto);
     return schedules;
+    // const schedules: ScheduleEntity[] =
+    //   await ScheduleEntity.findExistScheduleByJourneyId(journeyId);
+    // const monthlySchedules: ScheduleEntity[] = await Promise.all(
+    //   schedules.map(async (schedule) => {
+    //     const monthlySchedule = await ScheduleEntity.findMonthlySchedule(
+    //       schedule,
+    //       monthInfoDto,
+    //     );
+    //     console.log('4월 일정', monthlySchedule);
+    //     return monthlySchedule;
+    //   }),
+    // );
+
+    // return monthlySchedules;
   }
 
   //여정에 작성한 일지 개수 가지고 오기

--- a/src/schedule/schedule.entity.ts
+++ b/src/schedule/schedule.entity.ts
@@ -122,14 +122,19 @@ export class ScheduleEntity extends BaseEntity {
     journeyId,
     dates: MonthInfoDto,
   ): Promise<ScheduleEntity[]> {
-    const firstDate = new Date(`${dates.year}-${dates.month}-01`);
-    const lastDate = new Date(`${dates.year}-${dates.month}-31`);
-    const schedule = await ScheduleEntity.find({
+    const firstDate = new Date(dates.year, dates.month - 1, 1);
+    const lastDate = new Date(dates.year, dates.month, 0);
+    console.log('startDate : ', firstDate, 'lastDate', lastDate);
+    const monthlySchedule = await ScheduleEntity.find({
       where: {
         journey: { id: journeyId },
         date: Between(firstDate, lastDate),
       },
+      relations: ['location'],
     });
-    return schedule;
+    for (const schedule of monthlySchedule) {
+      console.log(schedule.date);
+    }
+    return monthlySchedule;
   }
 }


### PR DESCRIPTION
4,6,9,11월 등의 30일까지 밖에 없는 달의 일정이
다음 달 일정에 포함되는 오류 수정