### PR TITLE
[Fix] 메이트 탐색 데이터 누락 및 오류 수정 #115

### DIFF
--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -58,14 +58,16 @@ export class UserService {
   ): Promise<boolean> {
     // user가 targetUser를 팔로우하고 있는지 확인
 
-    const followingArray = user.following || [];
-    console.log('사용자가 팔로우하는 유저', user.following);
+    const isFollowing = await UserFollowingEntity.findOne({
+      where: {
+        user: { id: targetUserId },
+        followUser: { id: user.id }
+      }
+    });
 
-    const isFollowing = followingArray.some(
-      (following) => following.followUser.id === targetUserId,
-    );
+    if(isFollowing) return true;
+    else return false;
 
-    return isFollowing;
   }
 
   async findUserById(userId: number): Promise<UserEntity> {


### PR DESCRIPTION
## 요약
메이트 탐색 데이터 누락 및 오류 수정
<br><br>

## 작업 내용
- [ ] 팔로우 여부 반영 안되는 오류 수정
- [ ]  시그니처 상세보기: author 정보 누락
- [ ]  장소 기준 탐색: 가장 최신 시그니처 두 개가 아닌 관련 시그니처를 가져오도록 구현
- [ ]  랜덤 탐색에서 본인은 제외

<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #115

<br><br>



 