### PR TITLE
fix: 시그니처 상세보기 작성자 객체 null값 에러 해결 

### DIFF
--- a/src/signature/signature.controller.ts
+++ b/src/signature/signature.controller.ts
@@ -130,12 +130,34 @@ export class SignatureController {
           result
         );
       }
-      return new ResponseDto(
-        ResponseCode.GET_SIGNATURE_DETAIL_SUCCESS,
-        true,
-        "시그니처 상세보기 성공",
-        result
-      );
+
+      if(result.author){  // 작성자가 본인이 아닌 경우
+        if(result.author._id == null){  // 작성자가 탈퇴한 경우
+          return new ResponseDto(
+            ResponseCode.GET_SIGNATURE_DETAIL_SUCCESS,
+            true,
+            "시그니처 상세보기 성공: 작성자 탈퇴",
+            result
+          );
+        }
+        else{
+          return new ResponseDto(
+            ResponseCode.GET_SIGNATURE_DETAIL_SUCCESS,
+            true,
+            "시그니처 상세보기 성공: 메이트의 시그니처",
+            result
+          );
+
+        }
+      }
+      else{ // 작성자가 본인인 경우 author 없음
+        return new ResponseDto(
+          ResponseCode.GET_SIGNATURE_DETAIL_SUCCESS,
+          true,
+          "시그니처 상세보기 성공: 내 시그니처",
+          result
+        );
+      }
     }
     catch(error){
       console.log('Error on signatureId: ',error);

--- a/src/signature/signature.service.ts
+++ b/src/signature/signature.service.ts
@@ -140,8 +140,9 @@ export class SignatureService {
 
       // [2] 시그니처 작성자 정보 가져오기
       const authorDto: AuthorSignatureDto = new AuthorSignatureDto();
-      if(!authorDto){
-        if(loginUser.id != signature.user.id) {
+
+      if(signature.user){
+        if(loginUser.id != signature.user.id) { // 본인의 시그니처면 빈 객체를, 다르면 작성자의 프로필 정보를 담는다
           authorDto._id = signature.user.id;
           authorDto.name = signature.user.nickname;
 
@@ -157,7 +158,7 @@ export class SignatureService {
         }
       }
       else{ // 해당 시그니처를 작성한 유저가 존재하지 않는 경우(탈퇴한 경우)
-        console.log("유저가 존재하지 않습니다.");
+        console.log("작성자 유저가 존재하지 않습니다.");
         authorDto._id = null;
         authorDto.name = null;
         authorDto.image = null;
@@ -165,9 +166,6 @@ export class SignatureService {
         detailSignatureDto.author = authorDto;
       }
 
-      console.log("시그니처 작성자 id: ",signature.user.id);
-      console.log("로그인한 유저 id: ",loginUser.id);
-      // 본인의 시그니처면 빈 객체를, 다르면 작성자의 프로필 정보를 담는다
 
       /****************************************/
 


### PR DESCRIPTION

## 요약
fix: 시그니처 상세보기 작성자 객체 null값 에러 관련해서 예외처리를 구현했다. 
<br><br>

## 작업 내용
- [ ] 작성자가 탈퇴한 경우 authro 객체에 null값 담기
- [ ] 작성자 본인일 경우 author 객체 안보내기

<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #115

<br><br>

