### PR TITLE
[Refactor] 시그니처 상세보기: Response Dto 수정 #123

### DIFF
--- a/src/mate/mate.controller.ts
+++ b/src/mate/mate.controller.ts
@@ -15,9 +15,37 @@ export class MateController{
 
   constructor(private readonly mateService:MateService) {}
 
-  @Get('/location')
+
+  @Get('/random') // 메이트 탐색 첫째 줄: 랜덤으로 메이트 추천
   @UseGuards(UserGuard)
-  async getMateProfileWithMyFirstLocation( // 메이트 탐색 첫 줄: 나와 공통 장소를 사용한 메이트 추천
+  async getRandomMateProfileWithInfiniteCursor(
+    @Req() req: Request,
+    @Query() cursorPageOptionDto: CursorPageOptionsDto
+  ){
+    try{
+      const result = await this.mateService.recommendRandomMateWithInfiniteScroll(cursorPageOptionDto, req.user.id);
+
+      return new ResponseDto(
+        ResponseCode.GET_RANDOM_MATE_PROFILE_SUCCESS,
+        true,
+        "랜덤 메이트 추천 데이터 생성 성공",
+        result
+      );
+    }
+    catch(e){
+      console.log(e);
+      return new ResponseDto(
+        ResponseCode.GET_RANDOM_MATE_PROFILE_FAIL,
+        false,
+        "랜덤 메이트 추천 데이터 생성 실패",
+        null
+      );
+    }
+  }
+
+  @Get('/location') // 메이트 탐색 둘째 줄: 나와 공통 장소를 사용한 메이트 추천
+  @UseGuards(UserGuard)
+  async getMateProfileWithMyFirstLocation(
     @Req() req: Request,
   ): Promise<ResponseDto<MateWithCommonLocationResponseDto>> {
 
@@ -49,33 +77,6 @@ export class MateController{
           null
         );
       }
-
   }
 
-  @Get('/random')
-  @UseGuards(UserGuard)
-  async getRandomMateProfileWithInfiniteCursor( // 메이트 탐색 둘째 줄: 랜덤으로 메이트 추천
-    @Req() req: Request,
-    @Query() cursorPageOptionDto: CursorPageOptionsDto
-  ){
-    try{
-      const result = await this.mateService.recommendRandomMateWithInfiniteScroll(cursorPageOptionDto, req.user.id);
-
-      return new ResponseDto(
-        ResponseCode.GET_RANDOM_MATE_PROFILE_SUCCESS,
-        true,
-        "랜덤 메이트 추천 데이터 생성 성공",
-        result
-      );
-    }
-    catch(e){
-      console.log(e);
-      return new ResponseDto(
-        ResponseCode.GET_RANDOM_MATE_PROFILE_FAIL,
-        false,
-        "랜덤 메이트 추천 데이터 생성 실패",
-        null
-      );
-    }
-  }
 }

--- a/src/search/search.controller.ts
+++ b/src/search/search.controller.ts
@@ -14,7 +14,7 @@ export class SearchController{
 
   constructor(private readonly searchService: SearchService) {}
 
-  @Get('/')
+  @Get('/') // 팀색탭 메인: 인기 급상승, 메이트의 최신 시그니처
   @UseGuards(UserGuard)
   async getSearchMain(
     @Req() req: Request,
@@ -47,7 +47,7 @@ export class SearchController{
     }
   }
 
-  @Get('/find')
+  @Get('/find') // 탑색탭 검색: 키워드로 시그니처 검색하기
   async search(@Query('keyword') keyword: string): Promise<ResponseDto<CoverSignatureDto[]>> {
     try{
 

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -93,9 +93,8 @@ export class SearchService{
     return signatureCovers;
   }
 
-  async searchByKeyword(keyword: string) {
+  async searchByKeyword(keyword: string) {  // 키워드로 검색하기
     try{
-      // 키워드로 검색하기
       const resultSignatures = await SignatureEntity.find({
         where:{ title: Like(`%${keyword}%`) },
         relations: ['user'] // user 포함
@@ -115,8 +114,8 @@ export class SearchService{
   }
 
 
-  async getSignatureCover(signature:SignatureEntity):Promise<CoverSignatureDto>{
-    // 시그니처 커버 만들기
+  async getSignatureCover(signature:SignatureEntity)  // 시그니처 커버 만들기
+    :Promise<CoverSignatureDto>{
     const signatureCover = new CoverSignatureDto();
 
     signatureCover._id = signature.id;

--- a/src/signature/signature.controller.ts
+++ b/src/signature/signature.controller.ts
@@ -42,9 +42,9 @@ export class SignatureController {
     }
   }
 
-  @Post('/new')
+  @Post('/new') // 시그니처 생성하기
   @UseGuards(UserGuard)
-  async createNewSignature( // 시그니처 생성하기
+  async createNewSignature(
     @Body() newSignature: CreateSignatureDto,
     @Req() req: Request
   ): Promise<ResponseDto<any>> {
@@ -131,7 +131,7 @@ export class SignatureController {
         );
       }
 
-      if(result.author){  // 작성자가 본인이 아닌 경우
+      if(result.author.is_followed){  // 작성자가 본인이 아닌 경우
         if(result.author._id == null){  // 작성자가 탈퇴한 경우
           return new ResponseDto(
             ResponseCode.GET_SIGNATURE_DETAIL_SUCCESS,
@@ -147,7 +147,6 @@ export class SignatureController {
             "시그니처 상세보기 성공: 메이트의 시그니처",
             result
           );
-
         }
       }
       else{ // 작성자가 본인인 경우 author 없음

--- a/src/signature/signature.service.ts
+++ b/src/signature/signature.service.ts
@@ -142,20 +142,21 @@ export class SignatureService {
       const authorDto: AuthorSignatureDto = new AuthorSignatureDto();
 
       if(signature.user){
-        if(loginUser.id != signature.user.id) { // 본인의 시그니처면 빈 객체를, 다르면 작성자의 프로필 정보를 담는다
-          authorDto._id = signature.user.id;
-          authorDto.name = signature.user.nickname;
+        authorDto._id = signature.user.id;
+        authorDto.name = signature.user.nickname;
 
-          const image = await this.userService.getProfileImage(signature.user.id);
-          if(image == null) authorDto.image = null;
-          else{
-            authorDto.image = await this.s3Service.getImageUrl(image.imageKey);
-          }
+        const image = await this.userService.getProfileImage(signature.user.id);
+        if(image == null) authorDto.image = null;
+        else authorDto.image = await this.s3Service.getImageUrl(image.imageKey);
 
+        if(loginUser.id == signature.user.id) { // 시그니처 작성자가 본인이면 is_followed == null
+          authorDto.is_followed = null;
+        }
+        else{
           // 해당 시그니처 작성자를 팔로우하고 있는지 확인
           authorDto.is_followed = await this.userService.checkIfFollowing(loginUser,signature.user.id);
-          detailSignatureDto.author = authorDto;
         }
+        detailSignatureDto.author = authorDto;
       }
       else{ // 해당 시그니처를 작성한 유저가 존재하지 않는 경우(탈퇴한 경우)
         console.log("작성자 유저가 존재하지 않습니다.");
@@ -165,7 +166,6 @@ export class SignatureService {
         authorDto.is_followed = null;
         detailSignatureDto.author = authorDto;
       }
-
 
       /****************************************/
 


### PR DESCRIPTION

## 요약
[Refactor] 시그니처 상세보기: Response Dto 수정 #123
<br><br>

## 작업 내용
시그니처 상세보기에서 작성자가 본인일 경우 기존에는 작성자 정보를 보내지 않았는데
작성자 정보에 본인 정보를 담고 팔로우 여부에는 null을 담도록 수정한다.
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #이슈번호
#123 
<br><br>

