### PR TITLE
fix: 여행 규칙 댓글 무한 스크롤 초기값 설정

### DIFF
--- a/src/rule/rule.service.ts
+++ b/src/rule/rule.service.ts
@@ -114,12 +114,29 @@ export class RuleService {
 
   // [3] 여행 규칙 상세 페이지 조회 (댓글) - 페이지네이션
   async getComment(cursorPageOptionsDto: CursorPageOptionsDto, ruleId: number): Promise<CursorPageDto<GetCommentDto>> {
+
+    let cursorId: number = 0;
+
+    // (0) 초기값 가져오기
+    if(cursorPageOptionsDto.cursorId == 0){
+      const recentComment = await CommentEntity.findOne({
+        where: { rule: { id: ruleId } },
+        order: {
+          id: 'DESC' // id를 내림차순으로 정렬해서 가장 최근에 작성한 댓글 가져오기
+        }
+      });
+      cursorId = recentComment.id + 1;
+    }
+    else cursorId = cursorPageOptionsDto.cursorId;
+
+
+
     // (1) 데이터 조회
     const [comments, total] = await CommentEntity.findAndCount({
       take: cursorPageOptionsDto.take,
       where: {
         rule: { id: ruleId },
-        id: cursorPageOptionsDto.cursorId ? LessThan(cursorPageOptionsDto.cursorId) : null,
+        id: cursorId ? LessThan(cursorId) : null,
       },
       relations: {user:{profileImage: true}},
       order: {


### PR DESCRIPTION

## 요약
fix: 여행 규칙 댓글 무한 스크롤 초기값 설정
<br><br>

## 작업 내용
fix: 여행 규칙 댓글 무한 스크롤 초기값 설정
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #이슈번호

<br><br>

